### PR TITLE
MAkefile support and compiler warnings

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,14 +1,32 @@
 PLATFORM=$(shell uname -s)
 
 GPP=$(CXX)
-CPPFLAGS=-Wall -Wextra -std=c++17 -O3 -g -Izstr/src -Iparallel-hashmap/parallel_hashmap/ -Wno-unused-parameter -Icxxopts/include -Iconcurrentqueue `pkg-config --cflags zlib`
+
+#  FreeBSD absolutely must have __XSI_VISIBLE=1 and _POSIX_C_SOURCE=200112L defined.
+ifeq ($(PLATFORM), FreeBSD)
+CPPFLAGS  = -D__XSI_VISIBLE=1
+CPPFLAGS += -D_POSIX_C_SOURCE=200112L
+endif
+
+CPPFLAGS += -Wall -Wextra
+CPPFLAGS += -Wno-unused-parameter
+CPPFLAGS += -Wno-deprecated-declarations
+CPPFLAGS += -Wno-unused-lambda-capture
+CPPFLAGS += -Wno-unused-but-set-variable
+CPPFLAGS += -std=c++17 -pthread
+CPPFLAGS += -O3 -g
+CPPFLAGS += -Izstr/src
+CPPFLAGS += -Iparallel-hashmap/parallel_hashmap
+CPPFLAGS += -Icxxopts/include
+CPPFLAGS += -Iconcurrentqueue
+
+CPPFLAGS += $(shell pkg-config --cflags zlib)
+LIBS     += $(shell pkg-config --libs zlib)
 
 ODIR=obj
 BINDIR=bin
 SRCDIR=src
 LIBDIR=lib
-
-LIBS=`pkg-config --libs zlib`
 
 _DEPS = fastqloader.h CommonUtils.h MBGCommon.h VectorWithDirection.h FastHasher.h SparseEdgeContainer.h HashList.h UnitigGraph.h BluntGraph.h ReadHelper.h HPCConsensus.h ErrorMaskHelper.h CompressedSequence.h ConsensusMaker.h StringIndex.h LittleBigVector.h MostlySparse2DHashmap.h RankBitvector.h TwobitLittleBigVector.h UnitigResolver.h CumulativeVector.h UnitigHelper.h BigVectorSet.h Serializer.h DumbSelect.h MsatValueVector.h Node.h KmerMatcher.h
 DEPS = $(patsubst %, $(SRCDIR)/%, $(_DEPS))
@@ -16,10 +34,11 @@ DEPS = $(patsubst %, $(SRCDIR)/%, $(_DEPS))
 _OBJ = MBG.o fastqloader.o CommonUtils.o MBGCommon.o FastHasher.o SparseEdgeContainer.o HashList.o UnitigGraph.o BluntGraph.o HPCConsensus.o ErrorMaskHelper.o CompressedSequence.o ConsensusMaker.o StringIndex.o RankBitvector.o UnitigResolver.o UnitigHelper.o BigVectorSet.o ReadHelper.o Serializer.o DumbSelect.o MsatValueVector.o Node.o KmerMatcher.o
 OBJ = $(patsubst %, $(ODIR)/%, $(_OBJ))
 
-ifeq ($(PLATFORM),Linux)
-   LINKFLAGS = $(CPPFLAGS) -Wl,-Bstatic $(LIBS) -Wl,-Bdynamic -Wl,--as-needed -lpthread -pthread -static-libstdc++
+#  MacOS isn't happy with static/dynamic flags.
+ifeq ($(PLATFORM),Darwin)
+   LINKFLAGS = $(LIBS) -pthread -static-libstdc++
 else
-   LINKFLAGS = $(CPPFLAGS) $(LIBS) -lpthread -pthread -static-libstdc++
+   LINKFLAGS = -Wl,-Bstatic $(LIBS) -Wl,-Bdynamic -Wl,--as-needed -pthread -static-libstdc++
 endif
 
 VERSION := Branch $(shell git rev-parse --abbrev-ref HEAD) commit $(shell git rev-parse HEAD) $(shell git show -s --format=%ci)

--- a/src/ErrorMaskHelper.cpp
+++ b/src/ErrorMaskHelper.cpp
@@ -113,7 +113,7 @@ std::pair<CharType, LengthType> getCodeAndRunlength(const SequenceCharType& str,
 	for (size_t i = start; i < start+motifLength; i++)
 	{
 		uint16_t mask = 0;
-		assert(str[i] >= 0 && str[i] <= 3);
+		assert(str[i] <= 3);
 		mask = str[i];
 		motif <<= 2;
 		motif |= mask;

--- a/src/HPCConsensus.cpp
+++ b/src/HPCConsensus.cpp
@@ -21,7 +21,7 @@ void addCounts(ConsensusMaker& consensusMaker, const SequenceCharType& seq, cons
 			size_t expandedStart = poses[seqOff];
 			size_t expandedEnd = poses[seqOff+1];
 			assert(expandedEnd > expandedStart);
-			if (compressed >= 0 && compressed <= 3)
+			if (compressed <= 3)
 			{
 				expanded = expandedEnd - expandedStart;
 			}
@@ -35,7 +35,7 @@ void addCounts(ConsensusMaker& consensusMaker, const SequenceCharType& seq, cons
 			size_t expandedStart = poses[seqOff];
 			size_t expandedEnd = poses[seqOff+1];
 			assert(expandedEnd > expandedStart);
-			if (compressed >= 0 && compressed <= 3)
+			if (compressed <= 3)
 			{
 				expanded = expandedEnd - expandedStart;
 			}

--- a/src/MBG.cpp
+++ b/src/MBG.cpp
@@ -1537,7 +1537,6 @@ std::vector<DumbSelect> getUnitigExpandedPoses(const HashList& hashlist, const U
 
 void runMBG(const std::vector<std::string>& inputReads, const std::string& outputGraph, const size_t kmerSize, const size_t windowSize, const size_t minCoverage, const double minUnitigCoverage, const ErrorMasking errorMasking, const size_t numThreads, const bool includeEndKmers, const std::string& outputSequencePaths, const size_t maxResolveLength, const bool blunt, const size_t maxUnconditionalResolveLength, const std::string& nodeNamePrefix, const std::string& sequenceCacheFile, const bool keepGaps, const double hpcVariantOnecopyCoverage, const bool guesswork, const bool copycountFilterHeuristic, const bool onlyLocalResolve, const std::string& outputHomologyMap, const bool filterWithinUnitig, const bool doCleaning)
 {
-	auto beforeReading = getTime();
 	// check that all files actually exist
 	for (const std::string& name : inputReads)
 	{
@@ -1600,7 +1599,6 @@ void runMBG(const std::vector<std::string>& inputReads, const std::string& outpu
 	assert(unitigSequences.size() == unitigs.unitigs.size());
 	auto beforeConsistency = getTime();
 	AssemblyStats stats;
-	beforeConsistency = getTime();
 	verifyEdgeConsistency(unitigs, reads, stringIndex, unitigSequences, kmerSize);
 	auto beforeWrite = getTime();
 	if (blunt)

--- a/src/StringIndex.cpp
+++ b/src/StringIndex.cpp
@@ -27,7 +27,7 @@ void StringIndex::buildReverseIndex()
 
 std::string StringIndex::getString(uint16_t compressed, uint32_t index) const
 {
-	if (compressed >= 0 && compressed <= 3)
+	if (compressed <= 3)
 	{
 		std::string result;
 		for (size_t i = 0; i < index; i++)
@@ -67,7 +67,7 @@ uint32_t StringIndex::getReverseIndex(uint16_t compressed, uint32_t index) const
 
 uint32_t StringIndex::getIndex(uint16_t compressed, std::variant<size_t, std::string> expanded)
 {
-	if (compressed >= 0 && compressed <= 3)
+	if (compressed <= 3)
 	{
 		return std::get<size_t>(expanded);
 	}

--- a/src/UnitigResolver.cpp
+++ b/src/UnitigResolver.cpp
@@ -2319,7 +2319,6 @@ void replacePaths(ResolvableUnitigGraph& resolvableGraph, std::vector<PathGroup>
 		std::swap(readPaths[i].reads, newPath.reads);
 		assert(nodePosStarts.size() == nodePosEnds.size());
 		assert(nodePosEnds.size() == newPath.path.size());
-		assert(nodePosStarts[0] >= 0);
 		assert(nodePosEnds.back() <= kmerPathLength);
 		if (nodePosStarts[0] != 0 || nodePosEnds.back() != kmerPathLength)
 		{


### PR DESCRIPTION
I split the existing CXXFLAGS into multiple lines, added a few -Wno options, and removed redundant -lpthread from the link.  The rest of the changes are pretty simple.

Compilation:
 - Linux RHEL 8.9 is clean.
 - MacOS has not been tested.
 - FreeBSD 13.2 (gcc9) is clean.
 - FreeBSD 13.2 (clang14) still reports:
   ```
   src/HashList.h:47:9: warning: private field 'kmerSize' is not used [-Wunused-private-field]
           size_t kmerSize;
                  ^
   1 warning generated.
   ```

Execution has NOT been tested yet.  No need to merge until it is tested, and I guess MacOS too.  MacOS arm is known broken, correct?